### PR TITLE
fix: make rules behave consistently on win32

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1,9 +1,19 @@
 jobs:
   test:
-    runs-on: ubuntu-latest
-    environment: release
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: [18, 20]
+
+    runs-on: ${{ matrix.os }}
     name: Test
     steps:
+      - name: setup runner
+        if: ${{matrix.os == 'windows-latest'}}
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: setup repository
         uses: actions/checkout@v3
         with:
@@ -11,7 +21,8 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
       - run: npm ci
       - run: npm run lint
       - run: npm run test
@@ -27,3 +38,5 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  workflow_call:
+  

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,25 +1,25 @@
 jobs:
   test:
+    uses: ./.github/workflows/feature.yaml
+  release:
     runs-on: ubuntu-latest
-    environment: release
-    name: Test
+    needs: test
     steps:
-      - name: setup repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: setup node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run test
-      - run: npm run build
-      - run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: setup repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: setup node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: "18"
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: npx semantic-release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 name: Test, build and release
 on:
   push:

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,12 +41,13 @@
         "husky": "^7.0.4",
         "mocha": "^10.2.0",
         "react": "^18.2.0",
+        "rimraf": "^5.0.5",
         "semantic-release": "^20.0.0",
         "tsx": "^3.12.7",
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5270,6 +5271,20 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
@@ -6550,6 +6565,24 @@
       },
       "engines": {
         "node": ">=10.13"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
+      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/java-properties": {
@@ -10971,14 +11004,64 @@
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "dev": true,
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "husky": "^7.0.4",
     "mocha": "^10.2.0",
     "react": "^18.2.0",
+    "rimraf": "^5.0.5",
     "semantic-release": "^20.0.0",
     "tsx": "^3.12.7",
     "typescript": "^5.1.6"

--- a/src/rules/noBarrelImport.ts
+++ b/src/rules/noBarrelImport.ts
@@ -1,7 +1,7 @@
 import { dirname, relative, isAbsolute } from 'node:path';
 import { type TSESTree, type TSESLint } from '@typescript-eslint/utils';
 import * as recast from 'recast';
-import { createRule } from '../utilities';
+import { createRule, findRootPath } from '../utilities';
 import { findDirectory } from '../utilities/findDirectory';
 import ExportMapAny from './ExportMap';
 
@@ -78,7 +78,11 @@ export default createRule<Options, MessageIds>({
     // can't cycle-check a non-file
     if (myPath === '<text>') return {};
 
-    const myModuleRoot = findDirectory(dirname(myPath), 'package.json', '/');
+    const myModuleRoot = findDirectory(
+      dirname(myPath),
+      'package.json',
+      findRootPath(myPath),
+    );
 
     if (!myModuleRoot) {
       throw new Error('cannot find package.json');

--- a/src/rules/preferImportAlias.ts
+++ b/src/rules/preferImportAlias.ts
@@ -5,6 +5,8 @@
  * @see https://github.com/steelsojka/eslint-import-alias
  */
 import path from 'node:path';
+import { sep as posixSeparator } from 'node:path/posix';
+import { sep as win32Separator } from 'node:path/win32';
 import { createRule } from '../utilities';
 
 const RELATIVE_MATCHER = /^(?:(\.\/)|(\.\.\/))+/u;
@@ -58,10 +60,9 @@ export default createRule<Options, MessageIds>({
           path.resolve(parsedPath.dir, '../'.repeat(depth)),
         );
 
-        const importPath = path.relative(
-          baseDirectory,
-          path.resolve(parsedPath.dir, importValue),
-        );
+        const importPath = path
+          .relative(baseDirectory, path.resolve(parsedPath.dir, importValue))
+          .replaceAll(win32Separator, posixSeparator);
 
         for (const item of aliases) {
           const { alias, matchPath, matchParent, maxRelativeDepth = -1 } = item;

--- a/src/rules/requireExtension.ts
+++ b/src/rules/requireExtension.ts
@@ -1,8 +1,8 @@
 import { existsSync, lstatSync, readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, sep } from 'node:path';
 import { type TSESTree, type TSESLint } from '@typescript-eslint/utils';
 import resolveImport from 'eslint-module-utils/resolve';
-import { createRule } from '../utilities';
+import { createRule, findRootPath } from '../utilities';
 import { findDirectory } from '../utilities/findDirectory';
 import { readPackageJson } from '../utilities/readPackageJson';
 
@@ -94,7 +94,7 @@ const fixPathImport = (
   }
 
   for (const extension of extensions) {
-    if (resolvedImportPath.endsWith(lastSegment + '/index' + extension)) {
+    if (resolvedImportPath.endsWith(lastSegment + `${sep}index` + extension)) {
       return fixer.replaceTextRange(
         node.source.range,
         `'${
@@ -230,7 +230,7 @@ const handleAliasPath = (
   const targetPackageJsonPath = findDirectory(
     resolvedImportPath,
     'package.json',
-    '/',
+    findRootPath(resolvedImportPath),
   );
 
   if (targetPackageJsonPath) {
@@ -238,7 +238,7 @@ const handleAliasPath = (
       const currentPackageJsonPath = findDirectory(
         context.getFilename(),
         'package.json',
-        '/',
+        findRootPath(context.getFilename()),
       );
 
       if (

--- a/src/utilities/findRootPath.ts
+++ b/src/utilities/findRootPath.ts
@@ -1,0 +1,4 @@
+import { sep } from 'node:path';
+
+export const findRootPath = (startPath: string): string =>
+  process.platform === 'win32' ? `${startPath.split(sep)[0]}${sep}` : sep;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -3,3 +3,4 @@ export { getExportedName } from './getExportedName';
 export { isIgnoredFilename } from './isIgnoredFilename';
 export { isIndexFile } from './isIndexFile';
 export { parseFilename } from './parseFilename';
+export { findRootPath } from './findRootPath';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     "declaration": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "lib": [
+      "ES2021.String"
+    ],
     "module": "commonjs",
     "moduleResolution": "NodeNext",
     "noImplicitAny": false,


### PR DESCRIPTION
I noticed that multiple rules have a few issues on Windows:
1. `no-barrel-import`, `virtual-module`, and `require-extension` all assume `/` is the root of the fs on Windows, which ain't the case.
2. `prefer-import-alias`, `require-extensions` mix up the ECMA path separator and the OS path separator, which are not the same on Windows.
3. `virtual-module` mixed up the ECMA path separator and the OS path separator as well, but only in the logging, which can be confusing nonetheless.

https://github.com/gajus/eslint-plugin-canonical/blob/main/src/rules/virtualModule.ts#L29

https://github.com/gajus/eslint-plugin-canonical/blob/main/src/rules/noBarrelImport.ts#L84

To solve that, I propose the following:
1. In d7880fb, I move the ci setup from a single job to a matrix job that runs on both ubuntu-latest and windows-latest. We can see there that the CI does fail already, despite no changes in the source code.

2. Make everything works on Windows (todo addcommit sha):
    - Add a util to find the rootPath (so on Windows `C:/`, or some other letters and on Unix `/` . Leverage it wherever `/` was used directly with `findDirectory`. This fix issue 1
    - Normalize paths using `.replaceAll(win32Sep, posixSep)`. This fixes the two other issues