### PR TITLE
Update required Node version in package.json to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.1.6"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
When trying to install the current version with Node16, the following error appears: 

`roarr@7.21.0: The engine "node" is incompatible with this module. Expected version.
`

Since Roarr is one of the dependencies used, in that version, the actual required Node version is not Node16, but Node18.