### PR TITLE
fix: move @typescript-eslint/types to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@typescript-eslint/types": "^8.18.1",
         "@typescript-eslint/utils": "^8.18.1",
         "array-includes": "^3.1.8",
         "debug": "^4.4.0",
@@ -33,7 +34,6 @@
         "@types/node": "^22.10.2",
         "@typescript-eslint/parser": "^8.18.1",
         "@typescript-eslint/rule-tester": "^8.18.1",
-        "@typescript-eslint/types": "^8.18.1",
         "ajv": "^8.17.1",
         "chance": "^1.1.12",
         "eslint": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
+    "@typescript-eslint/types": "^8.18.1",
     "@typescript-eslint/utils": "^8.18.1",
     "array-includes": "^3.1.8",
     "debug": "^4.4.0",
@@ -30,7 +31,6 @@
     "@types/node": "^22.10.2",
     "@typescript-eslint/parser": "^8.18.1",
     "@typescript-eslint/rule-tester": "^8.18.1",
-    "@typescript-eslint/types": "^8.18.1",
     "ajv": "^8.17.1",
     "chance": "^1.1.12",
     "eslint": "^9.17.0",


### PR DESCRIPTION
@typescript-eslint/types is imported in shipped source files (noReExport, noReassignImports, noRestrictedImports, sortReactDependencies) but was listed as a devDependency, causing missing module errors for consumers.