### PR TITLE
chore: remove `array-includes` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@typescript-eslint/utils": "^8.18.1",
-        "array-includes": "^3.1.8",
         "debug": "^4.4.0",
         "doctrine": "^3.0.0",
         "eslint-import-resolver-typescript": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   },
   "dependencies": {
     "@typescript-eslint/utils": "^8.18.1",
-    "array-includes": "^3.1.8",
     "debug": "^4.4.0",
     "doctrine": "^3.0.0",
     "eslint-import-resolver-typescript": "^3.7.0",

--- a/src/rules/ExportMap.ts
+++ b/src/rules/ExportMap.ts
@@ -22,8 +22,6 @@ import * as unambiguous from 'eslint-module-utils/unambiguous';
 
 import { tsConfigLoader } from 'tsconfig-paths/lib/tsconfig-loader';
 
-import includes from 'array-includes';
-
 let ts;
 
 const log = debug('eslint-plugin-import:ExportMap');
@@ -662,7 +660,7 @@ ExportMap.parse = function (path, content, context) {
     }
 
     // This doesn't declare anything, but changes what's being exported.
-    if (includes(exports, n.type)) {
+    if (exports.includes(n.type)) {
       const exportedName = n.type === 'TSNamespaceExportDeclaration'
         ? (n.id || n.name).name
         : n.expression && n.expression.name || n.expression.id && n.expression.id.name || null;
@@ -676,7 +674,7 @@ ExportMap.parse = function (path, content, context) {
         'TSAbstractClassDeclaration',
         'TSModuleDeclaration',
       ];
-      const exportedDecls = ast.body.filter(({ type, id, declarations }) => includes(declTypes, type) && (
+      const exportedDecls = ast.body.filter(({ type, id, declarations }) => declTypes.includes(type) && (
         id && id.name === exportedName || declarations && declarations.find((d) => d.id.name === exportedName)
       ));
       if (exportedDecls.length === 0) {


### PR DESCRIPTION
This removes `array-includes` polyfill that is not required anymore
